### PR TITLE
Try new image path for CICD demo image

### DIFF
--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@
 # Professional contributions
 - Maintain the [LeiaLoft Unity SDK](https://www.leialoft.com/tools). The LeiaLoft Unity SDK creates a rig of stereo pairs of parallax cameras which all converge on a single plane
 - Maintain CICD processes for the LeiaLoft Unity SDK
-<img src="/_resources/UnitySDK_CICD.png?raw=true" height="100" width="177">
+<img src="https://github.com/johnasharifi/johnasharifi.github.io/blob/main/_resources/UnitySDK_CICD.png" height="100" width="177">
 - Shipped Unity SDK 0.6.x to public and internal users
 
 # Personal interests


### PR DESCRIPTION
Try new importation step for CICD image.

Image is visible on 
https://github.com/johnasharifi/johnasharifi.github.io/blob/main/index.md 
but not on
https://johnasharifi.github.io/